### PR TITLE
Update Installation Docs - Mainnet

### DIFF
--- a/bitcoin.md
+++ b/bitcoin.md
@@ -1,13 +1,13 @@
 # Install Bitcoin Blockchain
 
-**Note:** `btcuser` and `btcpass` are used for bitcoin RPC auth in this doc. Change as appropriate for your environment (be sure to update any configs etc used in these docs)
+**Note:** `btcuser` and `btcpass` are used for bitcoin RPC auth in this doc. Change as appropriate for your environment (be sure to update any configs etc used in these docs).
 
 Either a source install or running a pre-compiled bitcoin binary is required to run a stacks miner. \
-These instructions describe how to install v22.0 of the Bitcoin Blockchain - update the version number as new versions become available.
+These instructions describe how to install v25.0 of the Bitcoin Blockchain - update the version number as new versions become available.
 
 ## Scripted install
 
-You can use the [scripts/install_bitcoin.sh](./scripts/install_bitcoin.sh) to install and start bitcoin
+You can use the [scripts/install_bitcoin.sh](./scripts/install_bitcoin.sh) to install and start bitcoin:
 
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/stacksfoundation/miner-docs/main/scripts/install_bitcoin.sh | bash
@@ -18,8 +18,8 @@ curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/stacksfou
 Since we'll be importing a wallet into bitcoin, it's **highly recommended** that Bitcoin is compiled locally. \
 That said, to run a pre-compiled binary of `bitcoind`, you can download and install the binary using these commands:
 
-```
-$ export BTC_VERSION=0.20.0
+```bash
+$ export BTC_VERSION=25.0
 $ sudo curl -L https://bitcoin.org/bin/bitcoin-core-${BTC_VERSION}/bitcoin-${BTC_VERSION}-x86_64-linux-gnu.tar.gz -o /tmp/bitcoin-${BTC_VERSION}.tar.gz
 $ sudo tar -xzvf /tmp/bitcoin-${BTC_VERSION}.tar.gz -C /tmp
 $ sudo cp /tmp/bitcoin-${BTC_VERSION}/bin/* /usr/local/bin/
@@ -29,18 +29,26 @@ _later versions of bitcoin use a named wallet, as of stacks version `2.4.0.0.0` 
 
 ## Source Install
 
-```
-$ export BTC_VERSION=0.20.0
+```bash
+$ export BTC_VERSION=25.0
 $ git clone --depth 1 --branch v${BTC_VERSION} https://github.com/bitcoin/bitcoin /tmp/bitcoin && cd /tmp/bitcoin
-$ sh contrib/install_db4.sh .
+$ make -C depends NO_BOOST=1 NO_LIBEVENT=1 NO_QT=1 NO_SQLITE=1 NO_NATPMP=1 NO_UPNP=1 NO_ZMQ=1 NO_USDT=1
 $ ./autogen.sh
-$ export BDB_PREFIX="/tmp/bitcoin/db4" && ./configure BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include" \
- --disable-gui-tests \
- --enable-static \
- --without-miniupnpc \
- --with-pic \
- --enable-cxx \
- --with-boost-libdir=/usr/lib/x86_64-linux-gnu
+$ export BDB_PREFIX="$(ls -d $(pwd)/depends/* | grep "linux-gnu")"
+$ export CXXFLAGS="-O2"
+$ ./configure \
+  CXX=clang++ \
+  CC=clang \
+  BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" \
+  BDB_CFLAGS="-I${BDB_PREFIX}/include" \
+    --disable-gui-tests \
+    --disable-tests \
+    --without-miniupnpc \
+    --with-pic \
+    --enable-cxx \
+    --enable-static \
+    --disable-shared \
+    --prefix=/usr/local
 $ make -j2
 $ sudo make install
 ```
@@ -49,7 +57,7 @@ $ sudo make install
 
 **Note**: This sample config is open to the world for RPC. It can be restricted to localhost (`127.0.0.1`), **or** you can firewall the VM so it's only accessible from specific IP's.
 
-```
+```bash
 $ sudo bash -c 'cat <<EOF> /etc/bitcoin/bitcoin.conf
 server=1
 disablewallet=0
@@ -70,18 +78,21 @@ EOF'
 
 ## Add bitcoin user and set file ownership
 
-```
+```bash
 $ sudo useradd bitcoin
 $ sudo chown -R bitcoin:bitcoin /bitcoin/
 ```
 
 ## Install bitcoin systemd unit
 
-```
+```bash
 $ sudo bash -c 'cat <<EOF> /etc/systemd/system/bitcoin.service
 [Unit]
 Description=Bitcoin daemon
 After=network.target
+ConditionFileIsExecutable=/usr/local/bin/bitcoind
+ConditionPathExists=/bitcoin
+ConditionFileNotEmpty=/etc/bitcoin/bitcoin.conf
 
 [Service]
 ExecStart=/usr/local/bin/bitcoind -daemon \
@@ -128,7 +139,7 @@ EOF'
 
 ## Enable bitcoin service and start bitcoin
 
-```
+```bash
 $ sudo systemctl daemon-reload
 $ sudo systemctl enable bitcoin.service
 $ sudo systemctl start bitcoin.service
@@ -136,14 +147,14 @@ $ sudo systemctl start bitcoin.service
 
 **now we wait a few days until bitcoin syncs to chain tip**
 
-```
+```bash
 $ sudo tail -f /bitcoin/debug.log
 2022-07-19T14:33:12Z UpdateTip: new best=00000000000000000003c9ed0f9961b984e40082faa35bb9244f47ba0d68d6f2 height=745635 version=0x27ffe004 log2_work=93.635332 tx=750040284 date='2022-07-19T14:32:43Z' progress=1.000000 cache=161.3MiB(1219743txo)
 2022-07-19T14:33:25Z New outbound peer connected: version: 70015, blocks=745635, peer=118 (block-relay-only)
 ...
 
 $ bitcoin-cli \
- -rpcconnect=localhost \
+ -rpcconnect=127.0.0.1 \
  -rpcport=8332 \
  -rpcuser=btcuser \
  -rpcpassword=btcpass \

--- a/bitcoin.md
+++ b/bitcoin.md
@@ -73,6 +73,7 @@ rpcthreads=256
 rpcworkqueue=256
 rpctimeout=100
 txindex=1
+walletdir=/bitcoin/testnet3/wallets
 EOF'
 ```
 

--- a/bitcoin.md
+++ b/bitcoin.md
@@ -48,7 +48,7 @@ $ ./configure \
     --enable-cxx \
     --enable-static \
     --disable-shared \
-    --prefix=/usr/local
+    --bindir=/usr/local/bin
 $ make -j2
 $ sudo make install
 ```

--- a/bitcoin.md
+++ b/bitcoin.md
@@ -73,7 +73,6 @@ rpcthreads=256
 rpcworkqueue=256
 rpctimeout=100
 txindex=1
-walletdir=/bitcoin/testnet3/wallets
 EOF'
 ```
 

--- a/prerequisites.md
+++ b/prerequisites.md
@@ -22,10 +22,10 @@ Two options here - either are fine but it's _recommended_ to mount the chainstat
 
 1. Separate disks for chainstate(s) and OS:
    - mount a dedicated disk for bitcoin at `/bitcoin` of 1TB
-   - mount a dedicated disk for stacks-blockchain at `/stacks-blockchain` of at least 100GB
+   - mount a dedicated disk for stacks-blockchain at `/stacks-blockchain` of at least 250GB
    - root volume `/` of at least 25GB
 2. Combined Disk for all data:
-   - root volume `/` of at least 1TB
+   - root volume `/` of at least 1.3TB
 
 Create the required directories:
 
@@ -40,7 +40,7 @@ $ sudo mkdir -p /etc/stacks-blockchain
 
 Example:
 
-```
+```bash
 /dev/xvdb1 /bitcoin xfs rw,relatime,attr2,inode64,noquota
 /dev/xvdc1 /stacks-blockchain xfs rw,relatime,attr2,inode64,noquota
 ```
@@ -60,30 +60,36 @@ The following packages are required, and used by the rest of these docs
 ```bash
 $ curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash -
 $ sudo apt-get update -y && sudo apt-get install -y \
-    build-essential \
-    jq \
-    ncat \
-    nodejs \
-    git \
     autoconf \
-    libboost-system-dev \
-    libboost-filesystem-dev \
-    libboost-thread-dev \
-    libboost-chrono-dev \
-    libevent-dev \
-    libzmq5 \
-    libtool \
-    m4 \
     automake \
-    pkg-config \
-    libtool \
-    libboost-system-dev \
-    libboost-filesystem-dev \
+    autotools-dev \
+    build-essential \
+    clang \
+    curl \
+    git \
+    jq \
     libboost-chrono-dev \
+    libboost-dev \
+    libboost-filesystem-dev \
+    libboost-iostreams-dev \
     libboost-program-options-dev \
+    libboost-system-dev \
     libboost-test-dev \
     libboost-thread-dev \
-    libboost-iostreams-dev
+    libczmq-dev \
+    libevent-dev \
+    libnatpmp-dev \
+    libminiupnpc-dev \
+    libssl-dev \
+    libsqlite3-dev \
+    libtool \
+    libzmq5 \
+    m4 \
+    ncat \
+    nodejs \
+    pkg-config \
+    python3 \
+    wget
 $ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh && source $HOME/.cargo/env
 $ sudo npm install -g @stacks/cli rimraf shx
 ```

--- a/scripts/install_bitcoin.sh
+++ b/scripts/install_bitcoin.sh
@@ -1,6 +1,6 @@
 #!/bin/env bash
 
-BTC_VERSION=0.20.0
+BTC_VERSION=25.0
 
 REQUIRED_DIRS=(
     /bitcoin
@@ -18,17 +18,26 @@ echo "[ install_bitcoin.sh ] - Cloning bitcoin from https://github.com/bitcoin/b
 git clone --depth 1 --branch v${BTC_VERSION} https://github.com/bitcoin/bitcoin /tmp/bitcoin && cd /tmp/bitcoin || exit 1
 
 echo "[ install_bitcoin.sh ] - Installing DB4"
-sh contrib/install_db4.sh .
+make -C depends NO_BOOST=1 NO_LIBEVENT=1 NO_QT=1 NO_SQLITE=1 NO_NATPMP=1 NO_UPNP=1 NO_ZMQ=1 NO_USDT=1
 
 echo "[ install_bitcoin.sh ] - Building Bitcoin"
 ./autogen.sh
-export BDB_PREFIX="/tmp/bitcoin/db4" && ./configure BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include" \
-  --disable-gui-tests \
-  --enable-static \
-  --without-miniupnpc \
-  --with-pic \
-  --enable-cxx \
-  --with-boost-libdir=/usr/lib/x86_64-linux-gnu
+
+export BDB_PREFIX="$(ls -d $(pwd)/depends/* | grep "linux-gnu")"
+export CXXFLAGS="-O2"
+./configure \
+  CXX=clang++ \
+  CC=clang \
+  BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" \
+  BDB_CFLAGS="-I${BDB_PREFIX}/include" \
+    --disable-gui-tests \
+    --disable-tests \
+    --without-miniupnpc \
+    --with-pic \
+    --enable-cxx \
+    --enable-static \
+    --disable-shared \
+    --prefix=/usr/local
 make -j2
 
 echo "[ install_bitcoin.sh ] - Installing bitcoin"
@@ -62,6 +71,9 @@ sudo bash -c 'cat <<EOF> /etc/systemd/system/bitcoin.service
 [Unit]
 Description=Bitcoin daemon
 After=network.target
+ConditionFileIsExecutable=/usr/local/bin/bitcoind
+ConditionPathExists=/bitcoin
+ConditionFileNotEmpty=/etc/bitcoin/bitcoin.conf
 
 [Service]
 ExecStart=/usr/local/bin/bitcoind -daemon \

--- a/scripts/install_bitcoin.sh
+++ b/scripts/install_bitcoin.sh
@@ -63,7 +63,6 @@ rpcthreads=256
 rpcworkqueue=256
 rpctimeout=100
 txindex=1
-walletdir=/bitcoin/testnet3/wallets
 EOF'
 
 

--- a/scripts/install_bitcoin.sh
+++ b/scripts/install_bitcoin.sh
@@ -63,6 +63,7 @@ rpcthreads=256
 rpcworkqueue=256
 rpctimeout=100
 txindex=1
+walletdir=/bitcoin/testnet3/wallets
 EOF'
 
 

--- a/scripts/install_bitcoin.sh
+++ b/scripts/install_bitcoin.sh
@@ -37,7 +37,7 @@ export CXXFLAGS="-O2"
     --enable-cxx \
     --enable-static \
     --disable-shared \
-    --prefix=/usr/local
+    --bindir=/usr/local/bin
 make -j2
 
 echo "[ install_bitcoin.sh ] - Installing bitcoin"

--- a/scripts/prerequisites.sh
+++ b/scripts/prerequisites.sh
@@ -20,30 +20,36 @@ curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash -
 
 echo "[ prerequisites.sh ] - Installing required system packages"
 sudo apt-get update -y && sudo apt-get install -y \
-    build-essential \
-    jq \
-    ncat \
-    nodejs \
-    git \
     autoconf \
-    libboost-system-dev \
-    libboost-filesystem-dev \
-    libboost-thread-dev \
-    libboost-chrono-dev \
-    libevent-dev \
-    libzmq5 \
-    libtool \
-    m4 \
     automake \
-    pkg-config \
-    libtool \
-    libboost-system-dev \
-    libboost-filesystem-dev \
+    autotools-dev \
+    build-essential \
+    clang \
+    curl \
+    git \
+    jq \
     libboost-chrono-dev \
+    libboost-dev \
+    libboost-filesystem-dev \
+    libboost-iostreams-dev \
     libboost-program-options-dev \
+    libboost-system-dev \
     libboost-test-dev \
     libboost-thread-dev \
-    libboost-iostreams-dev
+    libczmq-dev \
+    libevent-dev \
+    libnatpmp-dev \
+    libminiupnpc-dev \
+    libssl-dev \
+    libsqlite3-dev \
+    libtool \
+    libzmq5 \
+    m4 \
+    ncat \
+    nodejs \
+    pkg-config \
+    python3 \
+    wget
 
 echo "[ prerequisites.sh ] - Installing Rust"
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/stacks-blockchain.md
+++ b/stacks-blockchain.md
@@ -35,10 +35,11 @@ bootstrap_node = "02196f005965cebe6ddc3901b7b1cc1aa7a88f305bb8c5893456b8f9a60592
 seed = "<npx privateKey from wallet.md>"
 # local_peer_seed = "" ## this value isn't required and is only used in peer networking
 miner = true
-mine_microblocks = true
+mine_microblocks = false
 wait_time_for_microblocks = 10000
 
 [burnchain]
+wallet_name = "miner"
 chain = "bitcoin"
 mode = "mainnet"
 peer_host = "127.0.0.1"
@@ -81,6 +82,7 @@ Requires=bitcoin.service
 After=bitcoin.service
 ConditionFileIsExecutable=/usr/local/bin/stacks-node
 ConditionPathExists=/stacks-blockchain/
+ConditionFileNotEmpty=/etc/stacks-blockchain/Config.toml
 
 [Service]
 ExecStart=/bin/sh -c "/usr/local/bin/stacks-node start --config /etc/stacks-blockchain/Config.toml >> /stacks-blockchain/miner.log 2>&1"
@@ -97,7 +99,7 @@ KillSignal=SIGTERM
 
 # Directory creation and permissions
 ####################################
-# Run as bitcoin:bitcoin
+# Run as stacks:stacks
 User=stacks
 Group=stacks
 RuntimeDirectory=stacks-blockchain
@@ -125,7 +127,7 @@ EOF'
 
 ## Enable service and start stacks
 
-```
+```bash
 $ sudo systemctl daemon-reload
 $ sudo systemctl enable stacks.service
 $ sudo systemctl start stacks.service

--- a/wallet.md
+++ b/wallet.md
@@ -33,6 +33,7 @@ $ npx @stacks/cli make_keychain 2>/dev/null | jq
 ## Create bitcoin wallet and import it into this instance
 
 We'll be using the wallet values from the previous `npx` command, "btcAddress" and "wif"
+
 _Import will only be successful after bitcoin has fully synced_
 
 ```bash
@@ -48,13 +49,6 @@ $ bitcoin-cli \
   false \
   false \
   true
-$ sudo systemctl restart bitcoin
-$ bitcoin-cli \
-  -rpcconnect=127.0.0.1 \
-  -rpcport=8332 \
-  -rpcuser=btcuser \
-  -rpcpassword=btcpass \
-  loadwallet miner
 $ bitcoin-cli \
   -rpcconnect=127.0.0.1 \
   -rpcport=8332 \
@@ -70,3 +64,38 @@ $ bitcoin-cli \
 ```
 
 Once imported, the wallet will need to be funded with some bitcoin.
+
+## Import an existing address into this instance
+
+We'll be using an existing "btcAddress" and "wif"
+
+_Import will only be successful after bitcoin has fully synced_
+
+```bash
+$ bitcoin-cli \
+  -rpcconnect=127.0.0.1 \
+  -rpcport=8332 \
+  -rpcuser=btcuser \
+  -rpcpassword=btcpass \
+  createwallet "miner" \
+  false \
+  false \
+  "" \
+  false \
+  false \
+  true
+$ bitcoin-cli \
+  -rpcconnect=127.0.0.1 \
+  -rpcport=8332 \
+  -rpcuser=btcuser \
+  -rpcpassword=btcpass \
+  importprivkey "<your wif>"
+$ bitcoin-cli \
+  -rpcconnect=127.0.0.1 \
+  -rpcport=8332 \
+  -rpcuser=btcuser \
+  -rpcpassword=btcpass \
+  getaddressinfo <your btcAddress>
+```
+
+The `importprivkey` method will trigger a full wallet rescan, which may take a while. The wallet will need to be funded with some bitcoin if it wasn't previously.

--- a/wallet.md
+++ b/wallet.md
@@ -37,17 +37,36 @@ _Import will only be successful after bitcoin has fully synced_
 
 ```bash
 $ bitcoin-cli \
-  -rpcconnect=localhost \
+  -rpcconnect=127.0.0.1 \
   -rpcport=8332 \
   -rpcuser=btcuser \
   -rpcpassword=btcpass \
-importmulti '[{ "scriptPubKey": { "address": "<npx btcAddress>" }, "timestamp":"now", "keys": [ "<npx wif>" ]}]' '{"rescan": true}'
+  createwallet "miner" \
+  false \
+  false \
+  "" \
+  false \
+  false \
+  true
+$ sudo systemctl restart bitcoin
 $ bitcoin-cli \
-  -rpcconnect=localhost \
+  -rpcconnect=127.0.0.1 \
   -rpcport=8332 \
   -rpcuser=btcuser \
   -rpcpassword=btcpass \
-getaddressinfo <npx btcAddress>
+  loadwallet miner
+$ bitcoin-cli \
+  -rpcconnect=127.0.0.1 \
+  -rpcport=8332 \
+  -rpcuser=btcuser \
+  -rpcpassword=btcpass \
+  importmulti '[{ "scriptPubKey": { "address": "<npx btcAddress>" }, "timestamp":"now", "keys": [ "<npx wif>" ]}]' '{"rescan": true}'
+$ bitcoin-cli \
+  -rpcconnect=127.0.0.1 \
+  -rpcport=8332 \
+  -rpcuser=btcuser \
+  -rpcpassword=btcpass \
+  getaddressinfo <npx btcAddress>
 ```
 
 Once imported, the wallet will need to be funded with some bitcoin.

--- a/wallet.md
+++ b/wallet.md
@@ -13,7 +13,9 @@ If using the **Scripted install** section of [stacks-blockchain.md](./stacks-blo
 
 ## Generate stacks-blockchain keychain
 
-**save this output in a safe place!**
+Note: Skip this step if you already have a keychain generated.
+
+**Save this output in a safe place!**
 
 ```bash
 $ cd $HOME && npm install @stacks/cli shx rimraf
@@ -31,6 +33,8 @@ $ npx @stacks/cli make_keychain 2>/dev/null | jq
 ```
 
 ## Create bitcoin wallet and import it into this instance
+
+Note: Skip this step if you already have a keychain generated.
 
 We'll be using the wallet values from the previous `npx` command, "btcAddress" and "wif"
 
@@ -54,13 +58,13 @@ $ bitcoin-cli \
   -rpcport=8332 \
   -rpcuser=btcuser \
   -rpcpassword=btcpass \
-  importmulti '[{ "scriptPubKey": { "address": "<npx btcAddress>" }, "timestamp":"now", "keys": [ "<npx wif>" ]}]' '{"rescan": true}'
+  importmulti '[{ "scriptPubKey": { "address": "<your btcAddress>" }, "timestamp":"now", "keys": [ "<your wif>" ]}]' '{"rescan": true}'
 $ bitcoin-cli \
   -rpcconnect=127.0.0.1 \
   -rpcport=8332 \
   -rpcuser=btcuser \
   -rpcpassword=btcpass \
-  getaddressinfo <npx btcAddress>
+  getaddressinfo <your btcAddress>
 ```
 
 Once imported, the wallet will need to be funded with some bitcoin.


### PR DESCRIPTION
Updated docs and scripts to install bitcoin v25.0 and stacks-blockchain v2.4.0.1.0, for mainnet.
Mirroring https://github.com/stacksfoundation/miner-docs/pull/2, which is a PR for testnet.